### PR TITLE
fix: admin panel user creation blocked by registration mode

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -173,8 +173,7 @@ export async function getAdminUsers(): Promise<AdminUser[]> {
 }
 
 export async function createAdminUser(username: string, password: string, email?: string): Promise<boolean> {
-  // Try public registration endpoint first, fallback to admin endpoint
-  const resp = await fetch(`${API_BASE}/api/2/register`, {
+  const resp = await request('/api/admin/users', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ username, password, email }),


### PR DESCRIPTION
## Summary

- **Bug**: the admin panel's "Create User" function was calling the public `/api/2/register` endpoint, which returns 403 when `RPODDER_REGISTRATION=closed`
- **Fix**: switched to the authenticated `/api/admin/users` endpoint, which is already protected by `require_auth_layer` + `require_admin_layer` middleware and correctly bypasses the public registration check
- No backend changes needed — the admin route already existed and was properly secured

## Test plan

- [ ] With `RPODDER_REGISTRATION=closed`, verify admin can create users from the admin panel
- [ ] Without a session, verify `POST /api/admin/users` returns 401
- [ ] With a non-admin session, verify `POST /api/admin/users` returns 403
- [ ] Public registration (`/api/2/register`) still returns 403 when registration is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)