### PR TITLE
fix: build frontend on native platform to fix arm64 Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,13 @@
 
 # --------------------------------------------------------------------------
 # Stage 1: Build frontend (Svelte + Tailwind)
-# Force amd64: output is pure static HTML/JS/CSS, identical for all arches.
-# Avoids running rolldown native bindings under QEMU (arm64 build fails).
+# Pin to $BUILDPLATFORM (the native arch of the build host) so bun runs
+# natively, never under QEMU. The output is pure static HTML/JS/CSS, identical
+# for all arches, so building it on the host arch is always correct. A constant
+# --platform=linux/amd64 here would force amd64-under-QEMU on the native arm64
+# runner, where bun crashes with SIGILL (issue surfaced after bun rolled to 1.3.x).
 # --------------------------------------------------------------------------
-FROM --platform=linux/amd64 oven/bun:1 AS frontend
+FROM --platform=$BUILDPLATFORM oven/bun:1 AS frontend
 
 WORKDIR /web
 COPY web/package.json web/bun.lock* ./


### PR DESCRIPTION
## Problem

The `2026.05.1` release workflow failed: the **Docker (arm64)** job crashed during `bun run build` with:

```
qemu: uncaught target signal 4 (Illegal instruction) - core dumped
error: script "build" was terminated by signal SIGILL
exit code: 132
```

## Root cause

The frontend stage was pinned to a **constant** `--platform=linux/amd64`. The arm64 job runs on a **native arm64 runner** (`ubuntu-24.04-arm`), so that pin forces amd64 `bun` to run under **QEMU emulation** — and `bun` 1.3.x crashes with SIGILL under QEMU.

The pin was correct back when both arches were QEMU-emulated on an amd64 host. Once the arm64 job moved to a native runner, the pin became backwards. The last release (2026-05-02) still worked because the floating `oven/bun:1` tag pointed at an older bun that tolerated emulation; it has since rolled to 1.3.x.

## Fix

Use `--platform=$BUILDPLATFORM` so `bun` always runs **natively** on the build host (amd64 on the amd64 runner, arm64 on the arm64 runner). The frontend output is platform-agnostic static HTML/JS/CSS, so building on the host arch is always correct, and QEMU is removed from the equation entirely. Also clears the `FromPlatformFlagConstDisallowed` buildx warning.

## Verification

Built the frontend stage for `linux/arm64` on a native arm64 host (replicating the CI runner): builds natively, no QEMU, no SIGILL, `dist/` produced. The arm64 Docker job only runs on `main`/tags (skipped on PRs), so the full arm64 build will be exercised on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to improve compatibility across different architectures, enhancing build reliability and performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thekoma/rpodder/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->